### PR TITLE
Remove "unzip bootra1n" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ You do not need to install additional software or an OS.
 > 64-bit: 5189966631b1fed316aa0b503e1a8f1e76fff1ad865138f673eeaa2ce886a60e   
 > 32-bit: 67cf2674e171b9b5efef0415d4c79a4a113e4050206b8aa9fdec1c6652e46370
 
-Unzip bootra1n into any directory, it should contain an ISO file.
-
 ### 2. Write bootra1n to USB
 - Rufus https://rufus.ie/
 


### PR DESCRIPTION
The download is now the .iso directly, it's not a .zip anymore. The README still tells users to unzip and get the iso inside. This confuses some users and they end up extracting the iso itself (see #36).

Remove instructions from README telling users to unzip the download.